### PR TITLE
[ADD] domain, dto, controller, respositoryTest 구현 완료

### DIFF
--- a/src/main/java/com/devaon/springwebservice/domain/BaseTimeEntity.java
+++ b/src/main/java/com/devaon/springwebservice/domain/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.devaon.springwebservice.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/devaon/springwebservice/domain/posts/Posts.java
+++ b/src/main/java/com/devaon/springwebservice/domain/posts/Posts.java
@@ -1,0 +1,37 @@
+package com.devaon.springwebservice.domain.posts;
+
+import com.devaon.springwebservice.domain.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+@Entity
+@NoArgsConstructor
+@Getter
+public class Posts extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    private String author;
+
+    @Builder
+    public Posts(String title, String content, String author){
+        this.title = title;
+        this.content = content;
+        this.author = author;
+    }
+}

--- a/src/main/java/com/devaon/springwebservice/domain/posts/PostsRepository.java
+++ b/src/main/java/com/devaon/springwebservice/domain/posts/PostsRepository.java
@@ -1,0 +1,11 @@
+package com.devaon.springwebservice.domain.posts;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+}

--- a/src/main/java/com/devaon/springwebservice/dto/PostsSaveRequestDto.java
+++ b/src/main/java/com/devaon/springwebservice/dto/PostsSaveRequestDto.java
@@ -1,0 +1,28 @@
+package com.devaon.springwebservice.dto;
+
+import com.devaon.springwebservice.domain.posts.Posts;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostsSaveRequestDto {
+    private String title;
+    private String content;
+    private String author;
+
+    public Posts toEntity(){
+        return Posts.builder()
+                .title(title)
+                .content(content)
+                .author(author)
+                .build();
+    }
+}

--- a/src/main/java/com/devaon/springwebservice/web/WebRestController.java
+++ b/src/main/java/com/devaon/springwebservice/web/WebRestController.java
@@ -1,0 +1,27 @@
+package com.devaon.springwebservice.web;
+
+import com.devaon.springwebservice.domain.posts.PostsRepository;
+import com.devaon.springwebservice.dto.PostsSaveRequestDto;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+
+@RestController
+@RequestMapping("/api/posts")
+@AllArgsConstructor
+public class WebRestController {
+
+    private PostsRepository postsRepository;
+
+    @PostMapping
+    public void postPosts(@RequestBody PostsSaveRequestDto dto){
+        postsRepository.save(dto.toEntity());
+    }
+
+}

--- a/src/test/java/com/devaon/springwebservice/domain/posts/PostsRepositoryTest.java
+++ b/src/test/java/com/devaon/springwebservice/domain/posts/PostsRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.devaon.springwebservice.domain.posts;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * Created by qwone4@gmail.com on 2020-04-29
+ * Blog : http://aonee.tistory.com
+ * Github : http://github.com/devAon
+ */
+
+@SpringBootTest
+class PostsRepositoryTest {
+    @Autowired
+    private PostsRepository postsRepository;
+
+    @Test
+    void getPostsTest(){
+        //given
+        postsRepository.save(Posts.builder()
+        .title("테스트 제목")
+        .content("테스트 본문")
+        .author("테스터")
+        .build());
+
+
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+        assertThat(posts.getTitle()).isEqualTo("테스트 제목");
+        assertThat(posts.getContent()).isEqualTo("테스트 본문");
+        assertThat(posts.getAuthor()).isEqualTo("테스터");
+    }
+
+    @Test
+    void BaseTimeEntityTest(){
+        //given
+        LocalDateTime now = LocalDateTime.now();
+
+        postsRepository.save(Posts.builder()
+                .title("테스트 제목")
+                .content("테스트 본문")
+                .author("테스터")
+                .build());
+
+
+        //when
+        List<Posts> postsList = postsRepository.findAll();
+
+        //then
+        Posts posts = postsList.get(0);
+        assertTrue(posts.getCreatedDate().isAfter(now));
+        assertTrue(posts.getModifiedDate().isAfter(now));
+
+    }
+
+}


### PR DESCRIPTION
**domain** - **Posts** (Entity 클래스)와  **PostsRepository** ( JpaRepository<Posts, Long>를 extends 상속받은 인터페이스)

**dto** - Posts의 Request와 Response용 DTO 생성

**controller** 

**respositoryTest** - **PostsRepository** 테스트 코드 작성을 통해 `게시글저장_불러오기` ,  `BaseTimeEntity_등록` 두개의 테스트를 통해 제대로 된 값을 반환되는지 검증했다.